### PR TITLE
fixing the position of the next starting value of i

### DIFF
--- a/WhenInRomeAPI/app/roman_numeral_converter.py
+++ b/WhenInRomeAPI/app/roman_numeral_converter.py
@@ -73,6 +73,9 @@ class RomanNumeralConverter:
             except Exception as exception:
                 raise exception
 
+            print(cur_numeral.numeral)
+            print(cur_numeral.value)
+            print(new_i)
             if largest_new_value == 0:
                 # Can't add anything more, so i raise
                 raise Exception("Invalid Numeral: Remaining sequence is larger")
@@ -97,8 +100,9 @@ class RomanNumeralConverter:
             else:
 
                 try:
-                    # We find the next numeral by sending in new_i + 1 as the position because new_i is the actual position of the character not the "_"
-                    next_numeral, new_i = self.get_numeral_starting_at_i(self.numeral, new_i+1)
+                    # We find the next numeral by sending in new_i + 1 as the position because new_i is the actual position of the character not the "_"\
+                    # We save the new position of numeral i to update only if we have a subtraction that is valid
+                    next_numeral, next_numeral_i = self.get_numeral_starting_at_i(self.numeral, new_i+1)
                 except Exception as exception:
                     raise exception
                 
@@ -135,7 +139,7 @@ class RomanNumeralConverter:
                     # When we add a subtraction to the sequence, we also offset the maximum we can add by the sequence sum
                     largest_new_value = subtraction_numeral.maxRestSequenceValue()
 
-                    i = new_i   
+                    i = next_numeral_i   
                     
                 else:
                     # We check if we can add the current numeral to the string
@@ -161,6 +165,7 @@ class RomanNumeralConverter:
                         largest_new_value = cur_numeral.maxRestSequenceValue()
                         self.number += cur_numeral.sequence_sum
 
+                    i = new_i 
             i += 1
         return self.number
 

--- a/WhenInRomeAPI/app/roman_numeral_converter.py
+++ b/WhenInRomeAPI/app/roman_numeral_converter.py
@@ -73,9 +73,6 @@ class RomanNumeralConverter:
             except Exception as exception:
                 raise exception
 
-            print(cur_numeral.numeral)
-            print(cur_numeral.value)
-            print(new_i)
             if largest_new_value == 0:
                 # Can't add anything more, so i raise
                 raise Exception("Invalid Numeral: Remaining sequence is larger")

--- a/WhenInRomeAPI/tests/test_roman_numeral_converter.py
+++ b/WhenInRomeAPI/tests/test_roman_numeral_converter.py
@@ -17,6 +17,9 @@ class TestRomanNumeralConverter:
         assert RomanNumeralConverter(numeral="IV").convert_to_number() == 4
         assert RomanNumeralConverter(numeral="IX").convert_to_number() == 9
 
+    def test_convert_to_number_with_bar(self):
+        assert RomanNumeralConverter(numeral="_XXXI").convert_to_number() == 10021
+
     def test_convert_to_number_invalid_ending(self):
         with pytest.raises(Exception, match="Invalid Numeral: Remaining sequence is larger"):
             RomanNumeralConverter(numeral="CLXIXII").convert_to_number()


### PR DESCRIPTION
Having a subtraction that didn't occur (in the example of _XXXI) would yield wrong positioning the next starting value of i. This fixes it by changing to the new value of a subtracted I only if the subtraction goes through, otherwise we use the new_i computed on the current element