### PR TITLE
fixing the position of i when we are on the last element

### DIFF
--- a/WhenInRomeAPI/app/roman_numeral_converter.py
+++ b/WhenInRomeAPI/app/roman_numeral_converter.py
@@ -95,6 +95,7 @@ class RomanNumeralConverter:
             if new_i + 1 == len(self.numeral):
                 # We are at the last numeral, no need to check the next one, we simply do the operation of checking and adding to the sequence
                 self.check_add_update_number_and_new_largest_value(cur_numeral, new_i)
+                i = new_i
             else:
 
                 try:

--- a/WhenInRomeAPI/tests/test_roman_numeral_converter.py
+++ b/WhenInRomeAPI/tests/test_roman_numeral_converter.py
@@ -18,6 +18,8 @@ class TestRomanNumeralConverter:
         assert RomanNumeralConverter(numeral="IX").convert_to_number() == 9
 
     def test_convert_to_number_with_bar(self):
+        assert RomanNumeralConverter(numeral="_X").convert_to_number() == 10000
+        assert RomanNumeralConverter(numeral="_V").convert_to_number() == 5000
         assert RomanNumeralConverter(numeral="_XXXI").convert_to_number() == 10021
 
     def test_convert_to_number_invalid_ending(self):


### PR DESCRIPTION
prevents double-counting of a powered element